### PR TITLE
Cut off special characters in resource file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ If outputDir is not specified, `./notes` is used. Use optional `--folders` flag 
 
 To get clean Markdown output without inline HTML tags for highlighted text, use `--noHighlights` flag.  
 
-Check [wiki](https://github.com/wormi4ok/evernote2md/wiki) section if you have problems running the tool.
+> ##### Note for macOS users!
+> Please, check this [wiki](https://github.com/wormi4ok/evernote2md/wiki/Run-the-binary-on-macOS-Catalina-or-higher) page if you have problems running the tool.
 
 #### With docker
 

--- a/internal/resource.go
+++ b/internal/resource.go
@@ -7,6 +7,7 @@ import (
 	"mime"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/wormi4ok/evernote2md/encoding/enex"
 	"github.com/wormi4ok/evernote2md/file"
@@ -18,7 +19,7 @@ var reFileAndExt = regexp.MustCompile(`(.*)(\.[^.]+)`)
 
 func decoder(d enex.Data) io.Reader {
 	if d.Encoding == "base64" {
-		return base64.NewDecoder(base64.StdEncoding, bytes.NewReader(d.Content))
+		return base64.NewDecoder(base64.StdEncoding, bytes.NewReader(bytes.TrimSpace(d.Content)))
 	}
 
 	return bytes.NewReader(d.Content)
@@ -51,7 +52,7 @@ func guessName(r enex.Resource) string {
 	case r.Attributes.Filename != "":
 		return r.Attributes.Filename
 	case r.Attributes.SourceUrl != "":
-		return path.Base(r.Attributes.SourceUrl)
+		return strings.TrimSpace(path.Base(r.Attributes.SourceUrl))
 	case r.ID != "":
 		return r.ID
 	default:

--- a/internal/resource.go
+++ b/internal/resource.go
@@ -15,7 +15,7 @@ import (
 
 var reImg = regexp.MustCompile(`^image/[\w]+`)
 
-var reFileAndExt = regexp.MustCompile(`(.*)(\.[^.]+)`)
+var reFileAndExt = regexp.MustCompile(`(.*)(\.[\w\d]+)`)
 
 func decoder(d enex.Data) io.Reader {
 	if d.Encoding == "base64" {


### PR DESCRIPTION
Try to extract only valid extension name from the media resource path and prevent filesystem issues while saving the file on the disk. 