### PR TITLE
Resolve #29 - Fix an edge case when notes overwrite each other

### DIFF
--- a/notes.go
+++ b/notes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/wormi4ok/evernote2md/encoding/markdown"
 	"github.com/wormi4ok/evernote2md/file"
@@ -70,7 +71,7 @@ func (d *noteFilesDir) Path() string {
 
 // uniqueName returns a unique note name
 func (d *noteFilesDir) uniqueName(title string) string {
-	name := file.BaseName(title)
+	name := strings.ToLower(file.BaseName(title))
 	if k, exist := d.names[name]; exist {
 		d.names[name] = k + 1
 		name = fmt.Sprintf("%s-%d", name, k)

--- a/notes_test.go
+++ b/notes_test.go
@@ -67,6 +67,25 @@ func TestNoteFilesDir_UniqueNames(t *testing.T) {
 	shouldExist(t, tmpDir+"/test_note-1.md")
 }
 
+// Test that notes with identical names but different casing don't override each other
+func TestNoteFilesDir_UniqueNames_CaseInsensitive(t *testing.T) {
+	tmpDir := t.TempDir()
+	d := newNoteFilesDir(tmpDir, false, false)
+
+	md := fakeNote(time.Now())
+	err := d.SaveNote("test_note", md)
+	if err != nil {
+		t.Errorf("SaveNote returned error: %s", err.Error())
+	}
+
+	err = d.SaveNote("TEST_note", md)
+	if err != nil {
+		t.Errorf("SaveNote returned error: %s", err.Error())
+	}
+
+	shouldExist(t, tmpDir+"/test_note-1.md")
+}
+
 func fakeNote(wantDate time.Time) *markdown.Note {
 	return &markdown.Note{
 		Content: []byte(`12345`),


### PR DESCRIPTION
Ensure that the names of the notes have the same casing when compare with already processed notes