### PR TITLE
Custom tag templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ evernote2md (flags) [input] [outputDir]
 
 If outputDir is not specified, `./notes` is used. Use optional `--folders` flag to put every note in a separate folder.
 
+An option `--tagTemplate` allows to change the way tags are formatted. See [wiki article](https://github.com/wormi4ok/evernote2md/wiki/Custom-tag-template) for more information. 
+
 To get clean Markdown output without inline HTML tags for highlighted text, use `--noHighlights` flag.
 
 Flag `--help` shows all available options.

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 )
 
-replace github.com/mattn/godown => github.com/wormi4ok/godown v0.1.1
+replace github.com/mattn/godown => github.com/wormi4ok/godown v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+tw
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/wormi4ok/godown v0.1.1 h1:XxQfSydgSUN7BCAODUJInyjI6mQ9keTYLZ7B9+iMTlc=
-github.com/wormi4ok/godown v0.1.1/go.mod h1:MqNOYIb1OoPw5X2AXQPM7tMVjGfD/fUYFIM0vDLsF94=
+github.com/wormi4ok/godown v0.1.2 h1:sQ1yKPMx3EQAi3quceJsKSavKxMhQEyPxOl/KHIYNrI=
+github.com/wormi4ok/godown v0.1.2/go.mod h1:MqNOYIb1OoPw5X2AXQPM7tMVjGfD/fUYFIM0vDLsF94=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/wormi4ok/evernote2md/encoding/enex"
@@ -18,46 +17,35 @@ import (
 type Converter struct {
 	TagFormat        string
 	EnableHighlights bool
+
+	// err holds an error during conversion
+	// Every conversion step should check this field and skip execution if it is not empty
+	err error
 }
 
-// Convert Evernote file to markdown
+// Convert an Evernote file to markdown
 func (c *Converter) Convert(note *enex.Note) (*markdown.Note, error) {
-	var md markdown.Note
+	md := new(markdown.Note)
 	md.Media = map[string]markdown.Resource{}
 
-	if err := mapResources(note, md); err != nil {
-		return nil, err
-	}
+	c.mapResources(note, md)
+	c.normalizeHTML(note, md, NewReplacerMedia(md.Media), &Code{}, &ExtraDiv{}, &TextFormatter{})
+	c.prependTags(note, md)
+	c.prependTitle(note, md)
+	c.toMarkdown(note, md)
+	c.trimSpaces(note, md)
+	c.addDates(note, md)
 
-	html, err := normalizeHTML(note.Content, NewReplacerMedia(md.Media), &Code{}, &ExtraDiv{}, &TextFormatter{})
-	if err != nil {
-		return nil, err
-	}
-
-	content := prependTags(note.Tags, string(html))
-	content = prependTitle(note.Title, content)
-
-	var b bytes.Buffer
-	err = markdown.Convert(&b, strings.NewReader(content), c.EnableHighlights)
-	if err != nil {
-		return nil, err
-	}
-
-	md.Content = regexp.MustCompile(`\n{3,}`).ReplaceAllLiteral(b.Bytes(), []byte("\n\n"))
-	md.Content = append(bytes.TrimRight(md.Content, "\n"), '\n')
-
-	md.CTime = convertEvernoteDate(note.Created)
-	md.MTime = convertEvernoteDate(note.Updated)
-	return &md, nil
+	return md, c.err
 }
 
-func mapResources(note *enex.Note, md markdown.Note) error {
+func (c *Converter) mapResources(note *enex.Note, md *markdown.Note) {
 	names := map[string]int{}
 	r := note.Resources
 	for i := range r {
 		p, err := ioutil.ReadAll(decoder(r[i].Data))
-		if err != nil {
-			return err
+		if c.err = err; err != nil {
+			return
 		}
 
 		rType := markdown.File
@@ -85,21 +73,58 @@ func mapResources(note *enex.Note, md markdown.Note) error {
 		} else {
 			md.Media[strconv.Itoa(i)] = mdr
 		}
-
 	}
-	return nil
 }
 
-func prependTags(tags []string, content string) string {
-	var tt []string
-	for _, t := range tags {
-		tt = append(tt, fmt.Sprintf("<code>%s</code>", t))
+func (c *Converter) prependTags(note *enex.Note, _ *markdown.Note) {
+	if c.err != nil {
+		return
 	}
-	return strings.Join(tt, " ") + "<br>" + content
+
+	var tt [][]byte
+	for _, t := range note.Tags {
+		tt = append(tt, []byte(fmt.Sprintf("<code>%s</code>", t)))
+	}
+	note.Content = append([]byte("<br>"), note.Content...)
+	note.Content = append(bytes.Join(tt, []byte(" ")), note.Content...)
 }
 
-func prependTitle(title, content string) string {
-	return fmt.Sprintf("<h1>%s</h1>", title) + content
+func (c *Converter) prependTitle(note *enex.Note, _ *markdown.Note) {
+	if c.err != nil {
+		return
+	}
+
+	note.Content = append([]byte(fmt.Sprintf("<h1>%s</h1>", note.Title)), note.Content...)
+}
+
+func (c *Converter) toMarkdown(note *enex.Note, md *markdown.Note) {
+	if c.err != nil {
+		return
+	}
+	var b bytes.Buffer
+	err := markdown.Convert(&b, bytes.NewReader(note.Content), c.EnableHighlights)
+	if c.err = err; err != nil {
+		return
+	}
+
+	md.Content = b.Bytes()
+}
+
+func (c *Converter) trimSpaces(_ *enex.Note, md *markdown.Note) {
+	if c.err != nil {
+		return
+	}
+
+	md.Content = regexp.MustCompile(`\n{3,}`).ReplaceAllLiteral(md.Content, []byte("\n\n"))
+	md.Content = append(bytes.TrimRight(md.Content, "\n"), '\n')
+}
+
+func (c *Converter) addDates(note *enex.Note, md *markdown.Note) {
+	if c.err != nil {
+		return
+	}
+	md.CTime = convertEvernoteDate(note.Created)
+	md.MTime = convertEvernoteDate(note.Updated)
 }
 
 const evernoteDateFormat = "20060102T150405Z"

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -15,10 +15,6 @@ import (
 	"github.com/wormi4ok/evernote2md/encoding/markdown"
 )
 
-const DefaultTagFormat = "`{{tag}}`"
-
-const tagToken = "{{tag}}"
-
 // Converter holds configuration options to control conversion
 type Converter struct {
 	TagFormat        string
@@ -92,20 +88,6 @@ func (c *Converter) mapResources(note *enex.Note, md *markdown.Note) {
 			md.Media[strconv.Itoa(i)] = mdr
 		}
 	}
-}
-
-func (c *Converter) prependTags(note *enex.Note, md *markdown.Note) {
-	if c.err != nil {
-		return
-	}
-
-	var tt [][]byte
-	for _, t := range note.Tags {
-		tt = append(tt, []byte(strings.Replace(c.TagFormat, tagToken, t, 1)))
-	}
-
-	md.Content = append([]byte("\n\n"), md.Content...)
-	md.Content = append(bytes.Join(tt, []byte(" ")), md.Content...)
 }
 
 func (c *Converter) prependTitle(note *enex.Note, md *markdown.Note) {

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -17,7 +17,7 @@ import (
 
 // Converter holds configuration options to control conversion
 type Converter struct {
-	TagFormat        string
+	TagTemplate      string
 	EnableHighlights bool
 
 	// err holds an error during conversion
@@ -25,16 +25,16 @@ type Converter struct {
 	err error
 }
 
-func NewConverter(tagFormat string, enableHighlights bool) (*Converter, error) {
-	if tagFormat == "" {
-		tagFormat = DefaultTagFormat
+func NewConverter(tagTemplate string, enableHighlights bool) (*Converter, error) {
+	if tagTemplate == "" {
+		tagTemplate = DefaultTagTemplate
 	}
 
-	if strings.Count(tagFormat, tagToken) != 1 {
+	if strings.Count(tagTemplate, tagToken) != 1 {
 		return nil, errors.New("tag format should contain exactly one {{tag}} template variable")
 	}
 
-	return &Converter{TagFormat: tagFormat, EnableHighlights: enableHighlights}, nil
+	return &Converter{TagTemplate: tagTemplate, EnableHighlights: enableHighlights}, nil
 }
 
 // Convert an Evernote file to markdown

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -16,6 +16,7 @@ import (
 
 // Converter holds configuration options to control conversion
 type Converter struct {
+	TagFormat        string
 	EnableHighlights bool
 }
 

--- a/internal/convert_test.go
+++ b/internal/convert_test.go
@@ -93,7 +93,7 @@ func TestConvert(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := &internal.Converter{EnableHighlights: true}
+		c, _ := internal.NewConverter("", true)
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := c.Convert(tt.arg)
 			if (err != nil) != tt.wantErr {

--- a/internal/replace.go
+++ b/internal/replace.go
@@ -42,8 +42,6 @@ func (c *Converter) normalizeHTML(note *enex.Note, _ *markdown.Note, rr ...TagRe
 		return
 	}
 	note.Content = out.Bytes()
-
-	return
 }
 
 // Media tag replacer puts a standard HTML <img> tag

--- a/internal/replace.go
+++ b/internal/replace.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/wormi4ok/evernote2md/encoding/enex"
 	"github.com/wormi4ok/evernote2md/encoding/markdown"
 )
 
@@ -17,10 +18,13 @@ type TagReplacer interface {
 	ReplaceTag(node *html.Node)
 }
 
-func normalizeHTML(b []byte, rr ...TagReplacer) ([]byte, error) {
-	doc, err := html.Parse(bytes.NewReader(b))
-	if err != nil {
-		return nil, err
+func (c *Converter) normalizeHTML(note *enex.Note, _ *markdown.Note, rr ...TagReplacer) {
+	if c.err != nil {
+		return
+	}
+	doc, err := html.Parse(bytes.NewReader(note.Content))
+	if c.err = err; err != nil {
+		return
 	}
 	var f func(*html.Node)
 	f = func(n *html.Node) {
@@ -34,11 +38,12 @@ func normalizeHTML(b []byte, rr ...TagReplacer) ([]byte, error) {
 	f(doc)
 
 	var out bytes.Buffer
-	if err := html.Render(&out, doc); err != nil {
-		return nil, err
+	if c.err = html.Render(&out, doc); c.err != nil {
+		return
 	}
+	note.Content = out.Bytes()
 
-	return out.Bytes(), nil
+	return
 }
 
 // Media tag replacer puts a standard HTML <img> tag

--- a/internal/tag.go
+++ b/internal/tag.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/wormi4ok/evernote2md/encoding/enex"
+	"github.com/wormi4ok/evernote2md/encoding/markdown"
+)
+
+const DefaultTagFormat = "`{{tag}}`"
+
+const tagToken = "{{tag}}"
+
+var spaces = regexp.MustCompile(`\s+`)
+
+func (c *Converter) prependTags(note *enex.Note, md *markdown.Note) {
+	if c.err != nil {
+		return
+	}
+
+	var tt [][]byte
+	for _, t := range note.Tags {
+		// Default tag format allows spaces in tags, but for custom formats
+		// we replace all spaces with underscores to prevent word splitting
+		if c.TagFormat != DefaultTagFormat {
+			t = spaces.ReplaceAllString(t, "_")
+		}
+
+		tt = append(tt, []byte(strings.Replace(c.TagFormat, tagToken, t, 1)))
+	}
+
+	md.Content = append([]byte("\n\n"), md.Content...)
+	md.Content = append(bytes.Join(tt, []byte(" ")), md.Content...)
+}

--- a/internal/tag.go
+++ b/internal/tag.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wormi4ok/evernote2md/encoding/markdown"
 )
 
-const DefaultTagFormat = "`{{tag}}`"
+const DefaultTagTemplate = "`{{tag}}`"
 
 const tagToken = "{{tag}}"
 
@@ -22,13 +22,13 @@ func (c *Converter) prependTags(note *enex.Note, md *markdown.Note) {
 
 	var tt [][]byte
 	for _, t := range note.Tags {
-		// Default tag format allows spaces in tags, but for custom formats
+		// Default tag template allows spaces in tags, but for custom templates
 		// we replace all spaces with underscores to prevent word splitting
-		if c.TagFormat != DefaultTagFormat {
+		if c.TagTemplate != DefaultTagTemplate {
 			t = spaces.ReplaceAllString(t, "_")
 		}
 
-		tt = append(tt, []byte(strings.Replace(c.TagFormat, tagToken, t, 1)))
+		tt = append(tt, []byte(strings.Replace(c.TagTemplate, tagToken, t, 1)))
 	}
 
 	md.Content = append([]byte("\n\n"), md.Content...)

--- a/internal/testdata/golden.md
+++ b/internal/testdata/golden.md
@@ -1,6 +1,6 @@
 # Test note
 
-`tag1``tag2`
+`tag1` `tag2`
 
 abc <span style="background-color: #ffaaaa">highlighted text</span>
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 func main() {
 	var input, outputOverride string
 	var outputDir = filepath.FromSlash("./notes")
-	var tagTemplate = "`{{tag}}`"
+	var tagTemplate = internal.DefaultTagFormat
 	var folders, noHighlights, resetTimestamps, debug bool
 
 	flaggy.AddPositionalValue(&input, "input", 1, true, "Evernote export file")

--- a/main.go
+++ b/main.go
@@ -34,14 +34,16 @@ func init() {
 }
 
 func main() {
-	var input string
+	var input, outputOverride string
 	var outputDir = filepath.FromSlash("./notes")
-	var outputOverride string
+	var tagTemplate = "`{{tag}}`"
 	var folders, noHighlights, resetTimestamps, debug bool
 
 	flaggy.AddPositionalValue(&input, "input", 1, true, "Evernote export file")
 	flaggy.AddPositionalValue(&outputDir, "output", 2, false, "Output directory")
-	flaggy.String(&outputOverride, "o", "outputDir", "Directory where markdown files will be created")
+
+	flaggy.String(&tagTemplate, "t", "tagTemplate", "Define how Evernote tags are formatted")
+	flaggy.String(&outputOverride, "o", "outputDir", "Override the directory where markdown files will be created")
 
 	flaggy.Bool(&folders, "", "folders", "Put every note in a separate folder")
 	flaggy.Bool(&noHighlights, "", "noHighlights", "Disable converting Evernote highlights to inline HTML tags")
@@ -55,7 +57,7 @@ func main() {
 	}
 
 	output := newNoteFilesDir(outputDir, folders, !resetTimestamps)
-	converter := internal.Converter{EnableHighlights: !noHighlights}
+	converter := internal.Converter{EnableHighlights: !noHighlights, TagFormat: tagTemplate}
 
 	setLogLevel(debug)
 

--- a/main.go
+++ b/main.go
@@ -57,14 +57,15 @@ func main() {
 	}
 
 	output := newNoteFilesDir(outputDir, folders, !resetTimestamps)
-	converter := internal.Converter{EnableHighlights: !noHighlights, TagFormat: tagTemplate}
+	converter, err := internal.NewConverter(tagTemplate, !noHighlights)
+	failWhen(err)
 
 	setLogLevel(debug)
 
 	run(input, output, newProgressBar(debug), converter)
 }
 
-func run(input string, output *noteFilesDir, progress *pb.ProgressBar, c internal.Converter) {
+func run(input string, output *noteFilesDir, progress *pb.ProgressBar, c *internal.Converter) {
 	i, err := os.Open(input)
 	failWhen(err)
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 func main() {
 	var input, outputOverride string
 	var outputDir = filepath.FromSlash("./notes")
-	var tagTemplate = internal.DefaultTagFormat
+	var tagTemplate = internal.DefaultTagTemplate
 	var folders, noHighlights, resetTimestamps, debug bool
 
 	flaggy.AddPositionalValue(&input, "input", 1, true, "Evernote export file")

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,8 @@ func Test_run(t *testing.T) {
 		t.Fatalf("failed to create a test file at %s", input)
 	}
 	output := newNoteFilesDir(tmpDir, false, false)
-	run(input, output, newProgressBar(false), internal.Converter{})
+	converter, _ := internal.NewConverter("", false)
+	run(input, output, newProgressBar(false), converter)
 
 	want := filepath.FromSlash(output.Path() + "/Test.md")
 	_, err = os.Stat(want)


### PR DESCRIPTION
Fixes #28 

This PR adds a new CLI option `--tagFormat` (the short version is `-t`) to allow overriding default presentation of Evernote note tags in the Markdown file.

By default, tags in the output file look like this:

```
# Note title

`tag1` `tag2`
```

With the new option you can run `evernote2md -t "#{{tag}}" export.enex` to get:

```
# Note title 

#tag1 #tag2
```