### PR TITLE
Batch file processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Key features:
 * Converts attachments to files ( two directories will be created: `image` for images and `file` for other attachments
   e.g. pdf files )
 * Retains correct links to attachments
-* Inserts Evernote tags in notes as text entries
+* Inserts Evernote tags in notes as text entries with customizable formatting
 * Shows highlighted Evernote text
 * Sets file created and modified date equal to the note attributes
 
@@ -41,11 +41,12 @@ Manually:
 evernote2md (flags) [input] [outputDir]
 ```
 
-If outputDir is not specified, `./notes` is used. Use optional `--folders` flag to put every note in a separate folder.
+`input` can be a file, a directory with exported files, or a glob pattern (like `exports/My*.enex`, for example).
 
-An option `--tagTemplate` allows to change the way tags are formatted. See [wiki article](https://github.com/wormi4ok/evernote2md/wiki/Custom-tag-template) for more information. 
+If `outputDir` is not specified, `./notes` is used. Add optional `--folders` flag to put every note in a separate folder.
 
-To get clean Markdown output without inline HTML tags for highlighted text, use `--noHighlights` flag.
+An option `--tagTemplate` allows to change the way tags are formatted. 
+See [wiki article](https://github.com/wormi4ok/evernote2md/wiki/Custom-tag-template) for more information.
 
 Flag `--help` shows all available options.
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	flaggy.Parse()
 
-	_ = matchInput(input)
+	_, _ = matchInput(input)
 
 	if len(outputOverride) > 0 {
 		outputDir = outputOverride
@@ -106,14 +106,16 @@ func newProgressBar(debug bool) *pb.ProgressBar {
 	return progress
 }
 
-func matchInput(input string) []string {
+func matchInput(input string) ([]string, error) {
 	var err error
 	if input == "" {
 		input, err = os.Getwd()
 	} else {
 		input, err = filepath.Abs(input)
 	}
-	failWhen(err)
+	if err != nil {
+		return nil, err
+	}
 
 	pattern := input
 	info, err := os.Stat(input)
@@ -124,10 +126,10 @@ func matchInput(input string) []string {
 	files, err := filepath.Glob(pattern)
 	failWhen(err)
 	if files == nil {
-		log.Fatal(fmt.Errorf("[ERROR] No enex files found in path: %s", input))
+		return nil, fmt.Errorf("[ERROR] No enex files found in path: %s", input)
 	}
 
-	return files
+	return files, nil
 }
 
 func setLogLevel(debug bool) {

--- a/main.go
+++ b/main.go
@@ -52,38 +52,33 @@ func main() {
 
 	flaggy.Parse()
 
-	_, _ = matchInput(input)
-
 	if len(outputOverride) > 0 {
 		outputDir = outputOverride
 	}
 
+	files, err := matchInput(input)
+	failWhen(err)
 	output := newNoteFilesDir(outputDir, folders, !resetTimestamps)
 	converter, err := internal.NewConverter(tagTemplate, !noHighlights)
 	failWhen(err)
 
 	setLogLevel(debug)
 
-	run(input, output, newProgressBar(debug), converter)
+	run(files, output, newProgressBar(debug), converter)
 }
 
-func run(input string, output *noteFilesDir, progress *pb.ProgressBar, c *internal.Converter) {
-	i, err := os.Open(input)
-	failWhen(err)
+func run(files []string, output *noteFilesDir, progress *pb.ProgressBar, c *internal.Converter) {
+	export := decodeFiles(files)
 
-	export, err := enex.Decode(i)
-	failWhen(err)
-
-	err = i.Close()
-	failWhen(err)
-
-	err = os.MkdirAll(output.Path(), os.ModePerm)
+	log.Printf("[DEBUG] Creating a directory: %s", output.Path())
+	err := os.MkdirAll(output.Path(), os.ModePerm)
 	failWhen(err)
 
 	progress.SetTotal(int64(len(export.Notes)))
 	progress.Start()
 	n := export.Notes
 	for i := range n {
+		log.Printf("[DEBUG] Converting a note: %s", n[i].Title)
 		md, err := c.Convert(&n[i])
 		failWhen(err)
 		err = output.SaveNote(n[i].Title, md)
@@ -106,6 +101,8 @@ func newProgressBar(debug bool) *pb.ProgressBar {
 	return progress
 }
 
+// matchInput finds all files matching input pattern
+// If input is a path to a directory, it will search for *.enex files inside the directory
 func matchInput(input string) ([]string, error) {
 	var err error
 	if input == "" {
@@ -126,10 +123,29 @@ func matchInput(input string) ([]string, error) {
 	files, err := filepath.Glob(pattern)
 	failWhen(err)
 	if files == nil {
-		return nil, fmt.Errorf("[ERROR] No enex files found in path: %s", input)
+		return nil, fmt.Errorf("[ERROR] No enex files found in the path: %s", input)
 	}
 
 	return files, nil
+}
+
+// decodeFiles creates a single Evernote export from multiple input files
+func decodeFiles(files []string) *enex.Export {
+	export := new(enex.Export)
+	for _, file := range files {
+		fd, err := os.Open(file)
+		failWhen(err)
+
+		log.Printf("[DEBUG] Decoding a file: %s", file)
+		e, err := enex.Decode(fd)
+		failWhen(err)
+
+		err = fd.Close()
+		failWhen(err)
+		export.Notes = append(export.Notes, e.Notes...)
+	}
+
+	return export
 }
 
 func setLogLevel(debug bool) {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	var tagTemplate = internal.DefaultTagTemplate
 	var folders, noHighlights, resetTimestamps, debug bool
 
-	flaggy.AddPositionalValue(&input, "input", 1, false, "Evernote export file")
+	flaggy.AddPositionalValue(&input, "input", 1, true, "Evernote export file, directory or a glob pattern")
 	flaggy.AddPositionalValue(&outputDir, "output", 2, false, "Output directory")
 
 	flaggy.String(&tagTemplate, "t", "tagTemplate", "Define how Evernote tags are formatted")

--- a/main_test.go
+++ b/main_test.go
@@ -44,78 +44,74 @@ func Test_run(t *testing.T) {
 }
 
 func Test_matchInput_cwd(t *testing.T) {
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Create(filepath.Join(tmpDir, "test_export.enex")); err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := tDir(t)
+	want := wantFile(t, tmpDir, "test_export.enex")
 
-	want := filepath.Join(tmpDir, "test_export.enex")
-	if got := matchInput(""); !matchPath(got, want) {
+	if got, _ := matchInput(""); !matchPath(got, want) {
 		t.Errorf("matchInput()\n got  %v\n want %v", got, want)
 	}
 }
 
 func Test_matchInput_file(t *testing.T) {
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := tDir(t)
+	want := wantFile(t, tmpDir, "test_export.enex")
 
-	want := filepath.Join(tmpDir, "export.enex")
-	if _, err := os.Create(want); err != nil {
-		t.Fatal(err)
-	}
-
-	if got := matchInput("export.enex"); !matchPath(got, want) {
+	if got, _ := matchInput("test_export.enex"); !matchPath(got, want) {
 		t.Errorf("matchInput()\n got  %v\n want %v", got, want)
 	}
 }
 
 func Test_matchInput_dir(t *testing.T) {
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := tDir(t)
+	wDir := wantDir(t, tmpDir, "testDir")
+	want := wantFile(t, wDir, "in_dir.enex")
 
-	if err := os.MkdirAll(filepath.Join(tmpDir, "test2"), 0777); err != nil {
-		t.Fatal(err)
-	}
-
-	want := filepath.Join(tmpDir, "test2", "in_dir.enex")
-	if _, err := os.Create(want); err != nil {
-		t.Fatal(err)
-	}
-
-	if got := matchInput("test2"); !matchPath(got, want) {
+	if got, _ := matchInput("testDir"); !matchPath(got, want) {
 		t.Errorf("matchInput()\n got  %v\n want %v", got, want)
 	}
 }
 
 func Test_matchInput_glob(t *testing.T) {
+	tmpDir := tDir(t)
+	wDir := wantDir(t, tmpDir, "testDir2")
+	want1 := wantFile(t, wDir, "glob1.enex")
+	want2 := wantFile(t, wDir, "glob2.enex")
+
+	if got, _ := matchInput("testDir2/glob*.enex"); !matchPath(got, want1, want2) {
+		t.Errorf("matchInput()\n got  %v\n want %v\n and  %v", got, want1, want2)
+	}
+}
+
+func Test_matchInput_fail(t *testing.T) {
+	_ = tDir(t)
+
+	if _, err := matchInput("not_exist.enex"); err == nil || !strings.HasPrefix(err.Error(), "[ERROR]") {
+		t.Errorf("matchInput() got unexpected eror %v", err)
+	}
+}
+
+func tDir(t *testing.T) string {
 	tmpDir := t.TempDir()
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatal(err)
 	}
+	return tmpDir
+}
 
-	if err := os.MkdirAll(filepath.Join(tmpDir, "test3"), 0777); err != nil {
+func wantFile(t *testing.T, path ...string) string {
+	filePath := filepath.Join(path...)
+	if _, err := os.Create(filePath); err != nil {
 		t.Fatal(err)
 	}
+	return filePath
+}
 
-	want1 := filepath.Join(tmpDir, "test3", "glob1.enex")
-	if _, err := os.Create(want1); err != nil {
+func wantDir(t *testing.T, path ...string) string {
+	dirPath := filepath.Join(path...)
+	if err := os.MkdirAll(filepath.Join(path...), 0777); err != nil {
 		t.Fatal(err)
 	}
-	want2 := filepath.Join(tmpDir, "test3", "glob2.enex")
-	if _, err := os.Create(want2); err != nil {
-		t.Fatal(err)
-	}
-
-	if got := matchInput("test3/glob*.enex"); !matchPath(got, want1, want2) {
-		t.Errorf("matchInput()\n got  %v\n want %v\n and  %v", got, want1, want2)
-	}
+	return dirPath
 }
 
 func matchPath(got []string, want ...string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -91,6 +91,16 @@ func Test_matchInput_fail(t *testing.T) {
 	}
 }
 
+func Test_matchInput_ignoreDirectories(t *testing.T) {
+	tmpDir := tDir(t)
+	_ = wantDir(t, tmpDir, "test1")
+	want := wantFile(t, tmpDir, "test1.enex")
+
+	if got, _ := matchInput("test*"); !matchPath(got, want) {
+		t.Errorf("matchInput()\n got  %v\n want %v", got, want)
+	}
+}
+
 func tDir(t *testing.T) string {
 	tmpDir := t.TempDir()
 	if err := os.Chdir(tmpDir); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -26,15 +26,16 @@ const sampleFile = `
 
 func Test_run(t *testing.T) {
 	setLogLevel(false)
-	tmpDir := t.TempDir()
+	tmpDir := tDir(t)
 	input := filepath.FromSlash(tmpDir + "/export.enex")
 	err := ioutil.WriteFile(input, []byte(sampleFile), 0600)
 	if err != nil {
 		t.Fatalf("failed to create a test file at %s", input)
 	}
+	files, _ := matchInput(input)
 	output := newNoteFilesDir(tmpDir, false, false)
 	converter, _ := internal.NewConverter("", false)
-	run(input, output, newProgressBar(false), converter)
+	run(files, output, newProgressBar(false), converter)
 
 	want := filepath.FromSlash(output.Path() + "/Test.md")
 	_, err = os.Stat(want)


### PR DESCRIPTION
Since Evernote has forbidden to export all your notes at once, the most efficient way now is to export notes by notebook, which creates as many files as you have notebooks. 

To keep the conversion as simple as one command, this PR changes how the input argument is processed.
It allows specifying input as a path to the export file, a directory, or a glob pattern. Evernote2md will search for `*.enex` files in the directory and process them all at once.