### PR TITLE
Fix #40 time created is not correct on macOS

### DIFF
--- a/encoding/enex/enex.go
+++ b/encoding/enex/enex.go
@@ -20,8 +20,8 @@ type (
 		XMLName    xml.Name   `xml:"note"`
 		Title      string     `xml:"title"`
 		Content    []byte     `xml:"content"`
-		Updated    string     `xml:"created"`
-		Created    string     `xml:"updated"`
+		Updated    string     `xml:"updated"`
+		Created    string     `xml:"created"`
 		Tags       []string   `xml:"tag"`
 		Attributes string     `xml:"note-attributes"`
 		Resources  []Resource `xml:"resource"`


### PR DESCRIPTION
- This resolves issue #40 on macOS
  (time created is always same as time modified after conversion)