### PR TITLE
Handle decoding notes with missing content

### DIFF
--- a/encoding/enex/enex_test.go
+++ b/encoding/enex/enex_test.go
@@ -75,7 +75,17 @@ func TestDecode(t *testing.T) {
 	if !reflect.DeepEqual(got, expect) {
 		t.Errorf("Decode() = %+v,\nwant %+v", got, expect)
 	}
+}
 
+func TestDecodeEmptyNote(t *testing.T) {
+	enexContent, err := os.Open("testdata/empty.enex")
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = enex.Decode(enexContent)
+	if err != nil {
+		t.Errorf("Error while Decoding = %v", err)
+	}
 }
 
 func readFile(filename string) []byte {

--- a/encoding/enex/testdata/empty.enex
+++ b/encoding/enex/testdata/empty.enex
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20210418T174314Z" application="Evernote" version="10.9.10">
+  <note>
+    <title>Empty</title>
+    <created>20210318T174301Z</created>
+    <updated>20210318T174304Z</updated>
+    <note-attributes>
+      <author>me</author>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      ]]>
+    </content>
+  </note>
+</en-export>


### PR DESCRIPTION
Fixes #45 

`enex.Decode` function will return a meaningful error message that contains a note or resource name along with an underlying error that library user can check using `errors.Is()`.

Added a test case to ensure that notes with empty contact don't cause any errors. 