### PR TITLE
Use hash from SourceUrl as backup resource ID

### DIFF
--- a/encoding/enex/enex.go
+++ b/encoding/enex/enex.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 )
 
 type (
@@ -81,6 +82,7 @@ type (
 func Decode(data io.Reader) (*Export, error) {
 	var e Export
 	err := newDecoder(data).Decode(&e)
+	re, _ := regexp.Compile(`\b[0-9a-f]{32}\b`)
 
 	for i := range e.Notes {
 		var c Content
@@ -97,6 +99,10 @@ func Decode(data io.Reader) (*Export, error) {
 		for j := range e.Notes[i].Resources {
 			var r Recognition
 			if len(e.Notes[i].Resources[j].Recognition) == 0 {
+				hash := re.FindString(e.Notes[i].Resources[j].Attributes.SourceUrl)
+				if len(hash) > 0 {
+					e.Notes[i].Resources[j].ID = hash
+				}
 				continue
 			}
 			decoder := newDecoder(bytes.NewReader(e.Notes[i].Resources[j].Recognition))


### PR DESCRIPTION
Simple fix for out-of-order media when <recognition> tag is absent but hashes can be found in the <source-url> tag as part of the en-cache:// URI.
Tested with export of old Penultimate notebook (note contents is a long series of PNGs only) from Evernote 10.19.2-mac-mas-public (458754) on macOS 10.15.7 19H1323.
This solution may be insufficient if Evernote/ENEX ever use hashes of a different length (regex would need changing) or if the SourceUrl ever contains multiple hashes (this code will only pick the first), or in the event of a hash collision (unlikely).
