### PR TITLE
Add flags to prepend dates to Markdown filenames

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	var input, outputOverride string
 	var outputDir = filepath.FromSlash("./notes")
 	var tagTemplate = internal.DefaultTagTemplate
-	var folders, noHighlights, resetTimestamps, addFrontMatter, debug bool
+	var folders, noHighlights, resetTimestamps, addFrontMatter, prependCDate, prependMDate, debug bool
 
 	flaggy.AddPositionalValue(&input, "input", 1, true, "Evernote export file, directory or a glob pattern")
 	flaggy.AddPositionalValue(&outputDir, "output", 2, false, "Output directory")
@@ -49,6 +49,8 @@ func main() {
 	flaggy.Bool(&noHighlights, "", "noHighlights", "Disable converting Evernote highlights to inline HTML tags")
 	flaggy.Bool(&resetTimestamps, "", "resetTimestamps", "Create files ignoring timestamps in the note attributes")
 	flaggy.Bool(&addFrontMatter, "", "addFrontMatter", "Prepend FrontMatter to markdown files")
+	flaggy.Bool(&prependCDate, "", "prependCDate", "Prepend creation date to markdown filenames")
+	flaggy.Bool(&prependMDate, "", "prependMDate", "Prepend modified date to markdown filenames")
 	flaggy.Bool(&debug, "v", "debug", "Show debug output")
 
 	flaggy.Parse()
@@ -59,7 +61,7 @@ func main() {
 
 	files, err := matchInput(input)
 	failWhen(err)
-	output := newNoteFilesDir(outputDir, folders, !resetTimestamps)
+	output := newNoteFilesDir(outputDir, folders, !resetTimestamps, prependCDate, prependMDate)
 	converter, err := internal.NewConverter(tagTemplate, addFrontMatter, !noHighlights)
 	failWhen(err)
 

--- a/notes.go
+++ b/notes.go
@@ -18,16 +18,20 @@ type noteFilesDir struct {
 	// flags modifying the logic for saving notes
 	flagFolders    bool
 	flagTimestamps bool
+	flagPrependCDate bool
+	flagPrependMDate bool
 
 	// A map to keep track of what notes are already created
 	names map[string]int
 }
 
-func newNoteFilesDir(output string, folders, timestamps bool) *noteFilesDir {
+func newNoteFilesDir(output string, folders, timestamps bool, prependCDate bool, prependMDate bool) *noteFilesDir {
 	return &noteFilesDir{
 		path:           output,
 		flagFolders:    folders,
 		flagTimestamps: timestamps,
+		flagPrependCDate: prependCDate,
+		flagPrependMDate: prependMDate,
 		names:          map[string]int{},
 	}
 }
@@ -35,6 +39,12 @@ func newNoteFilesDir(output string, folders, timestamps bool) *noteFilesDir {
 // SaveNote along with media resources
 func (d *noteFilesDir) SaveNote(title string, md *markdown.Note) error {
 	path := d.path
+	if d.flagPrependMDate {
+		title = md.MTime.Format("2006-01-02 ") + title
+	}
+	if d.flagPrependCDate {
+		title = md.CTime.Format("2006-01-02 ") + title
+	}
 	if d.flagFolders {
 		path = filepath.Join(d.path, d.uniqueName(title))
 		title = "README.md"


### PR DESCRIPTION
A simple pair of flags to prepend exported note filenames with the created and/or modified dates (ISO format, YYYY-MM-DD, so they sort nicely in file managers). 

Was useful for me, making the PR in case it's useful for others. However, a better long-term solution might be something like the proposal in Issue #58.

Cheers, Dan.