### PR TITLE
Fix for wrapped child nodes only writing the first child

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+evernote2md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 evernote2md
+notes/

--- a/internal/replace.go
+++ b/internal/replace.go
@@ -158,8 +158,8 @@ func (*ExtraDiv) ReplaceTag(n *html.Node) {
 		wrapper := n.FirstChild
 		if wrapper != nil && wrapper.Data == "div" {
 			for c := wrapper.FirstChild; c != nil; c = wrapper.FirstChild {
+				wrapper.RemoveChild(c)
 				if c.Data != "br" {
-					wrapper.RemoveChild(c)
 					n.AppendChild(c)
 				}
 			}

--- a/internal/replace.go
+++ b/internal/replace.go
@@ -157,13 +157,11 @@ func (*ExtraDiv) ReplaceTag(n *html.Node) {
 	if hasExtraDiv(n) {
 		wrapper := n.FirstChild
 		if wrapper != nil && wrapper.Data == "div" {
-			content := wrapper.FirstChild
-			if content == nil {
-				return
-			}
-			wrapper.RemoveChild(content)
-			if content.Data != "br" || content.FirstChild != nil {
-				n.AppendChild(content)
+			for c := wrapper.FirstChild; c != nil; c = wrapper.FirstChild {
+				if c.Data != "br" {
+					wrapper.RemoveChild(c)
+					n.AppendChild(c)
+				}
 			}
 			n.RemoveChild(wrapper)
 		}


### PR DESCRIPTION
Fix issue where a wrapper div with several children would write only the first child. Eg 


```html
<ul>
	<li>
		<div>This line has some 
			<b>bold</b>
			and 
			<i>italic</i>
			words</div>
	</li>
</ul>
```

Would export as

```markdown
- This line has some
```