### PR TITLE
 Change the file extension from .jpe to the more common .jpg extensio…

### DIFF
--- a/internal/resource.go
+++ b/internal/resource.go
@@ -71,5 +71,8 @@ func guessExt(mimeType string) string {
 	if err != nil || len(ext) == 0 {
 		return ""
 	}
+	if ext[0] == ".jpe" {
+		return ".jpg"
+	}
 	return ext[0]
 }


### PR DESCRIPTION
Change the file extension from .jpe to the more common .jpg extension for jpg files because some tools do not recognize .jpe.