### PR TITLE
Convert --en-checked:<bool> styles into <en-todo/> tags.

### DIFF
--- a/internal/convert.go
+++ b/internal/convert.go
@@ -76,7 +76,7 @@ func (c *Converter) Convert(note *enex.Note) (*markdown.Note, error) {
 	md.Media = map[string]markdown.Resource{}
 
 	c.mapResources(note, md)
-	c.normalizeHTML(note, md, NewReplacerMedia(md.Media), &Code{}, &ExtraDiv{}, &TextFormatter{}, &EmptyAnchor{})
+	c.normalizeHTML(note, md, NewReplacerMedia(md.Media), &Code{}, &ExtraDiv{}, &TextFormatter{}, &EmptyAnchor{}, &NormalizeTodo{})
 	c.toMarkdown(note, md)
 	c.prependTags(note, md)
 	c.prependTitle(note, md)


### PR DESCRIPTION
Fixes #50, at least for me.

The converter already understands `<en-todo/>` as todo items, but that tag doesn't appear in my export from today.
Instead, it contains `<li style="--en-checked:false;">`. It also has `style="--en-todo:true;` on the surrounding `<ul>`, but this PR ignores those.

I considered converting the `<li>`s directly, but that approach appears to require reimplementing `<li>` from scratch.
Instead, this PR wraps the contents of these `<li>`s in an `<en-todo/>` before converting to markdown to allow the existing code to handle them.