### PR TITLE
Add arm64 build for Linux, Windows and Android

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -6,15 +6,10 @@ builds:
   goarch:
   - amd64
   - arm64
-  ignore:
-  - goos: linux
-    goarch: arm64
-  - goos: windows
-    goarch: arm64
   env:
   - CGO_ENABLED=0
 archives:
-- name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}MacOS{{ else }}{{ title .Os }}{{ end }}_{{ if eq .Arch "amd64" }}64-bit{{ end }}{{ if eq .Arch "arm64" }}M1{{ end }}'
+- name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}MacOS{{ else }}{{ title .Os }}{{ end }}_{{ if eq .Arch "amd64" }}64-bit{{ end }}{{ if eq .Arch "arm64" }}{{ if eq .Os "darwin" }}M1{{ else }}arm64{{ end }}{{ end }}'
   format_overrides:
   - goos: windows
     format: zip

--- a/.release.yml
+++ b/.release.yml
@@ -3,6 +3,7 @@ builds:
   - darwin
   - linux
   - windows
+  - android
   goarch:
   - amd64
   - arm64


### PR DESCRIPTION
Currently, arm64 for these arch is not supported, make it hard to run this program on Termux (Android arm64) or something like this.
This PR adds builds for Linux arm64 and Windows arm64.

I've tested on Termux, it runs ~~smoothly~~. Windows arm64 build is not tested yet.

btw, IMHO, it is not accurate to tag MacOS arm64 as `M1`, as `M2` is also coming.

**Update**: Termux users should build with `GOGS=android`, [see](https://github.com/golang/go/issues/60125). For Termux user using `Linux arm64` build, `--resetTimestamps` must be passed, otherwise [exec.LookPath syscall will fail](https://github.com/wormi4ok/evernote2md/blob/master/file/os.go#L31)

The following image demonstrates running on Termux with `Android arm64` build.
![Console screenshot showing that this program functions properly](https://github.com/wormi4ok/evernote2md/assets/51789698/9b33563e-3e11-4762-b3c7-7106afa84899)
