### PR TITLE
Extend mapping of image MIME types to file extensions

### DIFF
--- a/internal/resource.go
+++ b/internal/resource.go
@@ -67,7 +67,14 @@ func guessName(r enex.Resource) string {
 }
 
 var preferredExt = map[string]string{
-	"image/jpeg": ".jpg",
+	"image/jpeg":    ".jpg",
+	"image/png":     ".png",
+	"image/gif":     ".gif",
+	"image/webp":    ".webp",
+	"image/svg+xml": ".svg",
+	"image/tiff":    ".tiff",
+	"image/bmp":     ".bmp",
+	"image/ico":     ".ico",
 }
 
 func guessExt(mimeType string) string {

--- a/internal/resource_test.go
+++ b/internal/resource_test.go
@@ -15,8 +15,14 @@ func Test_guessExt(t *testing.T) {
 		mimeType string
 		want     string
 	}{
-		{"image", "image/png", ".png"},
-		{"image", "image/jpeg", ".jpg"},
+		{"PNG image", "image/png", ".png"},
+		{"JPEG image", "image/jpeg", ".jpg"},
+		{"GIF image", "image/gif", ".gif"},
+		{"WebP image", "image/webp", ".webp"},
+		{"SVG image", "image/svg+xml", ".svg"},
+		{"TIFF image", "image/tiff", ".tiff"},
+		{"BMP image", "image/bmp", ".bmp"},
+		{"ICO image", "image/ico", ".ico"},
 		{"unknown mime type", "unknown", ""},
 		{"empty input", "", ""},
 	}


### PR DESCRIPTION
ENEX files can contain embedded image resources (without `file-name`) but with a MIME type. Here is an anonymized example:

```xml
<en-media type="image/png" hash="1xxx590685x61x4xxx1x24xxxxx0097x" alt="Some alt title" width="647" title="Some image title" height="324" style="box-sizing:border-box;max-width:100%;height:auto;border:0px;vertical-align:bottom;border-radius:4px;width:647px;" />

<!-- ... -->

<resource>
      <data encoding="base64"><!-- base64-encoded string here --></data>
      <mime>image/png</mime>
      <width>647</width>
      <height>324</height>
      <resource-attributes>
      <file-name></file-name>
      <source-url>en-cache://tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com%2Fresources%2Fx000%2F000000x0-0x0x-000x-xx0x-x0000000000x</source-url>
      </resource-attributes>
</resource>
```

With the current version of evernote2md, the above image is saved in the images folder _without_ the `.png` file extension, as shown in the markdown output:

```md
![tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com](image/tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com)
```

with the consequence that many Markdown preview tools (e.g. the standard Markdown extension in VS Code) will not display the image.

This PR solves this by extending the `preferredExt` map in `internal/resource.go` to provide many common image formats beyond `image/jpeg`.

NB: For legibility reasons it would be better IMHO to use the _hash_ (resource ID) (followed by the extension) to name such images, instead of the cumbersome source-url. I will open a separate PR for that (as it changes the current behaviour).
