### PR TITLE
Prefer resource ID over SourceURL for naming anonymous images

### DIFF
--- a/internal/resource.go
+++ b/internal/resource.go
@@ -50,17 +50,17 @@ func name(r enex.Resource) (name string, extension string) {
 
 // guessName of the res with the following priority:
 // 1. Filename attribute
-// 2. SourceUrl attribute
-// 3. ID of the res
+// 2. ID of the res (hash) - when filename is empty, prefer hash over SourceUrl
+// 3. SourceUrl attribute
 // 4. File type as name
 func guessName(r enex.Resource) string {
 	switch {
 	case r.Attributes.Filename != "":
 		return r.Attributes.Filename
-	case r.Attributes.SourceUrl != "":
-		return strings.TrimSpace(path.Base(r.Attributes.SourceUrl))
 	case r.ID != "":
 		return r.ID
+	case r.Attributes.SourceUrl != "":
+		return strings.TrimSpace(path.Base(r.Attributes.SourceUrl))
 	default:
 		return r.Type
 	}

--- a/internal/resource_test.go
+++ b/internal/resource_test.go
@@ -43,6 +43,13 @@ func Test_guessName(t *testing.T) {
 			Filename:  "!",
 			SourceUrl: "?",
 		}}, "!"},
+		{"empty filename prefers ID over SourceUrl", enex.Resource{
+			ID: "1xxx590685x61x4xxx1x24xxxxx0097x",
+			Attributes: enex.Attributes{
+				Filename:  "",
+				SourceUrl: "en-cache://tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com%2Fresources%2Fx000%2F000000x0-0x0x-000x-xx0x-x0000000000x",
+			},
+		}, "1xxx590685x61x4xxx1x24xxxxx0097x"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As mentioned in PR #133, ENEX files can contain embeded image resources with empty filenames:

```xml
<en-media type="image/png" hash="1xxx590685x61x4xxx1x24xxxxx0097x" alt="Some alt title" width="647" title="Some image title" height="324" style="box-sizing:border-box;max-width:100%;height:auto;border:0px;vertical-align:bottom;border-radius:4px;width:647px;" />

<!-- ... -->

<resource>
      <data encoding="base64"><!-- base64-encoded string here --></data>
      <mime>image/png</mime>
      <width>647</width>
      <height>324</height>
      <resource-attributes>
      <file-name></file-name>
      <source-url>en-cache://tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com%2Fresources%2Fx000%2F000000x0-0x0x-000x-xx0x-x0000000000x</source-url>
      </resource-attributes>
</resource>
```

In the function `guessName` in `internal/resource.go`, the SourceUrl has precedence over the ID. This PR reverses the order of precedence to prefer r.ID  over r.Attributes.SourceUrl.

This leads to a much cleaner output for the above:

```markdown
[!1xxx590685x61x4xxx1x24xxxxx0097x](images/1xxx590685x61x4xxx1x24xxxxx0097x)
```

instead of the less legible

```markdown
![tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com](image/tokenKey%3D%22AuthToken%3AUser%3A00000000%22+0x00xx00-0000-000x-0000-xx00x0xxx0x0+1xxx590685x61x4xxx1x24xxxxx0097x+https%3A%2F%2Fpublic.www.evernote.com)
```

(NB: with PR #133 the file extension `.png` would be added as well).